### PR TITLE
Support Python 3 in addition to Python 2.

### DIFF
--- a/extract_firmware.py
+++ b/extract_firmware.py
@@ -20,6 +20,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+from __future__ import print_function
+
 import itertools
 import mmap
 import os
@@ -27,7 +29,6 @@ import re
 import struct
 import sys
 import tempfile
-import urllib
 import zlib
 
 # The firmware changes fairly rarely. From a limited sample, when the
@@ -57,27 +58,27 @@ for (VERSION, ARCH) in product(VERSIONS, ARCHES):
     if os.path.exists("NVIDIA-Linux-%s-%s" % (ARCH, VERSION)):
         break
 else:
-    print """Please run this in a directory where NVIDIA-Linux-x86-%(version)s is a subdir.
+    print("""Please run this in a directory where NVIDIA-Linux-x86-%(version)s is a subdir.
 
 You can make this happen by running
 wget http://us.download.nvidia.com/XFree86/Linux-x86/%(version)s/NVIDIA-Linux-x86-%(version)s.run
 sh NVIDIA-Linux-x86-%(version)s.run --extract-only
 
 Note: You can use other versions/arches, see the source for what is acceptable.
-""" % {"version": VERSIONS[-1]}
+""" % {"version": VERSIONS[-1]})
     sys.exit(1)
 
-kernel_f = open("NVIDIA-Linux-%s-%s/kernel/nv-kernel.o" % (ARCH, VERSION), "r")
+kernel_f = open("NVIDIA-Linux-%s-%s/kernel/nv-kernel.o" % (ARCH, VERSION), "rb")
 kernel = mmap.mmap(kernel_f.fileno(), 0, access=mmap.ACCESS_READ)
 
-user_f = open("NVIDIA-Linux-%s-%s/libnvcuvid.so.%s" % (ARCH, VERSION, VERSION), "r")
+user_f = open("NVIDIA-Linux-%s-%s/libnvcuvid.so.%s" % (ARCH, VERSION, VERSION), "rb")
 user = mmap.mmap(user_f.fileno(), 0, access=mmap.ACCESS_READ)
 
-vp2_kernel_prefix = "\xcd\xab\x55\xee\x44"
-vp2_user_prefix = "\xce\xab\x55\xee\x20\x00\x00\xd0\x00\x00\x00\xd0"
-vp4_kernel_prefix = "\xf1\x97\x00\x42\xcf\x99"
-vp3_user_prefix = "\x64\x00\xf0\x20\x64\x00\xf1\x20\x64\x00\xf2\x20"
-vp3_vc1_prefix = "\x43\x00\x00\x34" * 2
+vp2_kernel_prefix = b"\xcd\xab\x55\xee\x44"
+vp2_user_prefix = b"\xce\xab\x55\xee\x20\x00\x00\xd0\x00\x00\x00\xd0"
+vp4_kernel_prefix = b"\xf1\x97\x00\x42\xcf\x99"
+vp3_user_prefix = b"\x64\x00\xf0\x20\x64\x00\xf1\x20\x64\x00\xf2\x20"
+vp3_vc1_prefix = b"\x43\x00\x00\x34" * 2
 
 # List of chip revisions since the fuc loader expects nvXX_fucXXX files
 VP2_CHIPS = ["nv84"] # there are more, but no need for more symlinks
@@ -101,17 +102,20 @@ def vp5_offset():
         return 0xb3
     return 0xb7
 
+def at_offset_is(data, offset, bs):
+    return data[offset:offset+1] == bs
+
 BLOBS = {
     # VP2 kernel xuc
     "nv84_bsp": {
         "data": kernel,
-        "start": vp2_kernel_prefix + "\x46",
+        "start": vp2_kernel_prefix + b"\x46",
         "length": 0x16f3c,
         "links": links(VP2_CHIPS, "xuc103"),
     },
     "nv84_vp": {
         "data": kernel,
-        "start": vp2_kernel_prefix + "\x7c",
+        "start": vp2_kernel_prefix + b"\x7c",
         "length": 0x1ae6c,
         "links": links(VP2_CHIPS, "xuc00f"),
     },
@@ -119,23 +123,23 @@ BLOBS = {
     # VP3 kernel fuc
     "nv98_bsp": {
         "data": kernel,
-        "start": "\xf1\x07\x00\x10\xf1\x03\x00\x00",
+        "start": b"\xf1\x07\x00\x10\xf1\x03\x00\x00",
         "length": 0xac00,
-        "pred": lambda data, i: data[i+vp3_offset()] == '\x8e',
+        "pred": lambda data, i: at_offset_is(data, i+vp3_offset(), b'\x8e'),
         "links": links(VP3_CHIPS, "fuc084"),
     },
     "nv98_vp": {
         "data": kernel,
-        "start": "\xf1\x07\x00\x10\xf1\x03\x00\x00",
+        "start": b"\xf1\x07\x00\x10\xf1\x03\x00\x00",
         "length": 0xa500,
-        "pred": lambda data, i: data[i+vp3_offset()] == '\x95',
+        "pred": lambda data, i: at_offset_is(data, i+vp3_offset(), b'\x95'),
         "links": links(VP3_CHIPS, "fuc085"),
     },
     "nv98_ppp": {
         "data": kernel,
-        "start": "\xf1\x07\x00\x08\xf1\x03\x00\x00",
+        "start": b"\xf1\x07\x00\x08\xf1\x03\x00\x00",
         "length": 0x3800,
-        "pred": lambda data, i: data[i+vp3_offset()] == '\x30',
+        "pred": lambda data, i: at_offset_is(data, i+vp3_offset(), b'\x30'),
         "links": links(VP3_CHIPS, "fuc086"),
     },
 
@@ -144,21 +148,21 @@ BLOBS = {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0x10200,
-        "pred": lambda data, i: data[i+8*11+1] == '\xcf',
+        "pred": lambda data, i: at_offset_is(data, i+8*11+1, b'\xcf'),
         "links": links(VP4_0_CHIPS, "fuc084"),
     },
     "nva3_vp": {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0xc600,
-        "pred": lambda data, i: data[i+8*11+1] == '\x9e',
+        "pred": lambda data, i: at_offset_is(data, i+8*11+1, b'\x9e'),
         "links": links(VP4_0_CHIPS, "fuc085"),
     },
     "nva3_ppp": {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0x3f00,
-        "pred": lambda data, i: data[i+8*11+1] == '\x36',
+        "pred": lambda data, i: at_offset_is(data, i+8*11+1, b'\x36'),
         "links": links(VP4_0_CHIPS, "fuc086"),
     },
 
@@ -167,21 +171,21 @@ BLOBS = {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0x10d00,
-        "pred": lambda data, i: data[i+0x59] == '\xd8',
+        "pred": lambda data, i: at_offset_is(data, i+0x59, b'\xd8'),
         "links": links(VP4_2_CHIPS, "fuc084"),
     },
     "nvc0_vp": {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0xd300,
-        "pred": lambda data, i: data[i+0x59] == '\xa5',
+        "pred": lambda data, i: at_offset_is(data, i+0x59, b'\xa5'),
         "links": links(VP4_2_CHIPS, "fuc085"),
     },
     "nvc0_ppp": {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0x4100,
-        "pred": lambda data, i: data[i+0x59] == '\x38',
+        "pred": lambda data, i: at_offset_is(data, i+0x59, b'\x38'),
         "links": links(VP4_2_CHIPS, "fuc086") + links(VP5_CHIPS, "fuc086"),
     },
 
@@ -190,51 +194,51 @@ BLOBS = {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0x11c00,
-        "pred": lambda data, i: data[i+vp5_offset()] == '\x27',
+        "pred": lambda data, i: at_offset_is(data, i+vp5_offset(), b'\x27'),
         "links": links(VP5_CHIPS, "fuc084"),
     },
     "nve0_vp": {
         "data": kernel,
         "start": vp4_kernel_prefix,
         "length": 0xdd00,
-        "pred": lambda data, i: data[i+vp5_offset()] == '\x0a',
+        "pred": lambda data, i: at_offset_is(data, i+vp5_offset(), b'\x0a'),
         "links": links(VP5_CHIPS, "fuc085"),
     },
 
     # VP2 user xuc
     "nv84_bsp-h264": {
         "data": user,
-        "start": vp2_user_prefix + "\x88",
+        "start": vp2_user_prefix + b"\x88",
         "length": 0xd9d0,
     },
     "nv84_vp-h264-1": {
         "data": user,
-        "start": vp2_user_prefix + "\x3c",
+        "start": vp2_user_prefix + b"\x3c",
         "length": 0x1f334,
     },
     "nv84_vp-h264-2": {
         "data": user,
-        "start": vp2_user_prefix + "\x04",
+        "start": vp2_user_prefix + b"\x04",
         "length": 0x1bffc,
     },
     "nv84_vp-mpeg12": {
         "data": user,
-        "start": vp2_user_prefix + "\x4c",
+        "start": vp2_user_prefix + b"\x4c",
         "length": 0x22084,
     },
     "nv84_vp-vc1-1": {
         "data": user,
-        "start": vp2_user_prefix + "\x7c",
+        "start": vp2_user_prefix + b"\x7c",
         "length": 0x2cd24,
     },
     "nv84_vp-vc1-2": {
         "data": user,
-        "start": vp2_user_prefix + "\xa4",
+        "start": vp2_user_prefix + b"\xa4",
         "length": 0x1535c,
     },
     "nv84_vp-vc1-3": {
         "data": user,
-        "start": vp2_user_prefix + "\x34",
+        "start": vp2_user_prefix + b"\x34",
         "length": 0x133bc,
     },
 
@@ -243,31 +247,31 @@ BLOBS = {
         "data": user,
         "start": vp3_user_prefix,
         "length": 0xb00,
-        "pred": lambda data, i: data[i + 11 * 8] == '\x4a' and data[i + 228] == '\x43',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8, b'\x4a') and at_offset_is(data, i + 228, b'\x43'),
     },
     "vuc-vp3-h264-0": {
         "data": user,
         "start": vp3_user_prefix,
         "length": 0x1600,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\xff' and data[i + 225] == '\x81',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\xff') and at_offset_is(data, i + 225, b'\x81'),
     },
     "vuc-vp3-vc1-0": {
         "data": user,
         "start": vp3_vc1_prefix + vp3_user_prefix,
         "length": 0x1d00,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\xf4',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\xf4'),
     },
     "vuc-vp3-vc1-1": {
         "data": user,
         "start": vp3_vc1_prefix + vp3_user_prefix,
         "length": 0x2100,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\x34',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\x34'),
     },
     "vuc-vp3-vc1-2": {
         "data": user,
         "start": vp3_vc1_prefix + vp3_user_prefix,
         "length": 0x2300,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\x98',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\x98'),
     },
 
     # VP4.x user vuc
@@ -275,62 +279,62 @@ BLOBS = {
         "data": user,
         "start": vp3_user_prefix,
         "length": 0xc00,
-        "pred": lambda data, i: data[i + 11 * 8] == '\x4a' and data[i + 228] == '\x44',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8, b'\x4a') and at_offset_is(data, i + 228, b'\x44'),
         "links": ["vuc-mpeg12-0"],
     },
     "vuc-vp4-h264-0": {
         "data": user,
         "start": vp3_user_prefix,
         "length": 0x1900,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\xff' and data[i + 225] == '\x8c',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\xff') and at_offset_is(data, i + 225, b'\x8c'),
         "links": ["vuc-h264-0"],
     },
     "vuc-vp4-mpeg4-0": {
         "data": user,
         "start": vp3_user_prefix,
         "length": 0x1d00,
-        "pred": lambda data, i: data[i + 61] == '\x30' and data[i + 6923] == '\x00',
+        "pred": lambda data, i: at_offset_is(data, i + 61, b'\x30') and at_offset_is(data, i + 6923, b'\x00'),
         "links": ["vuc-mpeg4-0"],
     },
     "vuc-vp4-mpeg4-1": {
         "data": user,
         "start": vp3_user_prefix,
         "length": 0x1d00,
-        "pred": lambda data, i: data[i + 61] == '\x30' and data[i + 6923] == '\x20',
+        "pred": lambda data, i: at_offset_is(data, i + 61, b'\x30') and at_offset_is(data, i + 6923, b'\x20'),
         "links": ["vuc-mpeg4-1"],
     },
     "vuc-vp4-vc1-0": {
         "data": user,
         "start": vp3_vc1_prefix + vp3_user_prefix,
         "length": 0x1d00,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\xb4',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\xb4'),
         "links": ["vuc-vc1-0"],
     },
     "vuc-vp4-vc1-1": {
         "data": user,
         "start": vp3_vc1_prefix + vp3_user_prefix,
         "length": 0x2100,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\x08',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\x08'),
         "links": ["vuc-vc1-1"],
     },
     "vuc-vp4-vc1-2": {
         "data": user,
         "start": vp3_vc1_prefix + vp3_user_prefix,
         "length": 0x2100,
-        "pred": lambda data, i: data[i + 11 * 8 + 1] == '\x6c',
+        "pred": lambda data, i: at_offset_is(data, i + 11 * 8 + 1, b'\x6c'),
         "links": ["vuc-vc1-2"],
     },
 }
 
 # Build a regex on the start data to speed things along.
-start_re = "|".join(set(re.escape(v["start"]) for v in BLOBS.itervalues()))
-files = set(v["data"] for v in BLOBS.itervalues())
+start_re = b"|".join(set(re.escape(v["start"]) for v in BLOBS.values()))
+files = set(v["data"] for v in BLOBS.values())
 
 done = set()
 
 for data in files:
     for match in re.finditer(start_re, data):
-        for name, v in BLOBS.iteritems():
+        for name, v in BLOBS.items():
             if name in done or data != v["data"] or match.group(0) != v["start"]:
                 continue
 
@@ -342,7 +346,7 @@ for data in files:
             length = v["length"]
             links = v.get("links", [])
 
-            with open(os.path.join(cwd, name), "w") as f:
+            with open(os.path.join(cwd, name), "wb") as f:
                 f.write(data[i:i+length])
 
             done.add(name)
@@ -354,7 +358,7 @@ for data in files:
                 os.symlink(name, link)
 
 for name in set(BLOBS) - done:
-    print "Firmware %s not found, ignoring." % name
+    print("Firmware %s not found, ignoring." % name)
 
 ARCHIVE_FILES = {
     0: "fuc409d",
@@ -374,13 +378,13 @@ def decompress(prefix, start, s):
     try:
         decomp = zlib.decompressobj(-zlib.MAX_WBITS)
         data = decomp.decompress(s[10:])
-    except Exception, e:
-        print prefix, repr(s[:16]), len(s)
-        print e
+    except Exception as e:
+        print(prefix, repr(s[:16]), len(s))
+        print(e)
         return False
     magic, count = struct.unpack("<II", data[:8])
     if magic != 0:
-        print "Skipping gzip blob at 0x%x (%d bytes)" % (start, len(data))
+        print("Skipping gzip blob at 0x%x (%d bytes)" % (start, len(data)))
         return False
 
     # Allow valid archives to be skipped
@@ -389,7 +393,7 @@ def decompress(prefix, start, s):
 
     entries = []
     # Each entry is id, length, offset
-    for i in xrange(count):
+    for i in range(count):
         entry = struct.unpack("<III", data[8 + i * 12:8 + (i + 1) * 12])
         entries.append(entry)
 
@@ -406,14 +410,13 @@ def decompress(prefix, start, s):
 
 if VERSION in ARCHIVE_ORDERS:
     gzip_starts = list(m.start(0) for m in re.finditer(
-        re.escape("\x1f\x8b\x08"), kernel))
+        re.escape(b"\x1f\x8b\x08"), kernel))
     idx = 0
     names = ARCHIVE_ORDERS[VERSION]
-    for start, end in itertools.izip(gzip_starts,
-                                     gzip_starts[1:] + [len(kernel)]):
+    for start, end in zip(gzip_starts, gzip_starts[1:] + [len(kernel)]):
         if decompress(names[idx], start, kernel[start:end]):
             idx += 1
     if idx != len(names):
-        print "Unexpected quantity of archives in blob, graph fw likely wrong."
+        print("Unexpected quantity of archives in blob, graph fw likely wrong.")
 else:
-    print "Unknown PGRAPH archive order in this version."
+    print("Unknown PGRAPH archive order in this version.")


### PR DESCRIPTION
`b'\xaa'[0]` gives different results in Python 2 and 3. So `at_offset_is()` is added to work around this issue. Other changes work in both Python 2 and 3.